### PR TITLE
Update es-ES.ts

### DIFF
--- a/modules/locales/es-ES.ts
+++ b/modules/locales/es-ES.ts
@@ -19,5 +19,5 @@ export default {
   before_optimized: 'Antes',
   after_optimized: 'Después',
   new_version: 'Actualizar',
-  apply_now: 'Apply now', // TODO: translate
+  apply_now: 'Aplicar ahora',
 }


### PR DESCRIPTION
Finished (missing) Spanish translation:
line 22 was:
  apply_now: 'Apply now', // TODO: translate
fixed to:
  apply_now: 'Aplicar ahora',